### PR TITLE
Update install.md

### DIFF
--- a/sphinx/source/docs/install.md
+++ b/sphinx/source/docs/install.md
@@ -66,7 +66,10 @@ vcs import src --recursive < krs_alpha.repos  # about 5 mins
 # 5. build the workspace and deploy firmware for hardware acceleration
 ###################################################
 source /tools/Xilinx/Vitis/2020.2/settings64.sh  # source Xilinx tools
-source /opt/ros/foxy/setup.bash  # Sources system ROS 2 installation
+source /opt/ros/foxy/setup.bash  # Sources system ROS 2 installation. 
+# Note: The path above is valid if one installs ROS 2 from a pre-built 
+# package. If one builds ROS 2 from the source the directory might 
+# vary (e.g. ~/ros2_foxy/ros2-linux).
 export PATH="/usr/bin":$PATH  # FIXME: adjust path for CMake 3.5+
 colcon build --merge-install  # about 2 mins
 


### PR DESCRIPTION
A comment has been added to the build instruction to help the user in case he takes a different path to building and installing ROS 2.