### PR TITLE
Fix issues with colcon-acceleration, minor spacing fixes

### DIFF
--- a/krs.repos
+++ b/krs.repos
@@ -9,7 +9,7 @@ repositories:
   acceleration/colcon-acceleration:
     type: git
     url: https://github.com/ros-acceleration/colcon-acceleration
-    version: 0.1.0
+    version: 0.2.0
   acceleration/ros2acceleration:
     type: git
     url: https://github.com/ros-acceleration/ros2acceleration

--- a/sphinx/source/docs/install.md
+++ b/sphinx/source/docs/install.md
@@ -52,7 +52,7 @@ repositories:
   acceleration/colcon-acceleration:
     type: git
     url: https://github.com/ros-acceleration/colcon-acceleration
-    version: 0.1.0
+    version: 0.2.0
   acceleration/ros2acceleration:
     type: git
     url: https://github.com/ros-acceleration/ros2acceleration
@@ -76,9 +76,9 @@ vcs import src --recursive < krs_alpha.repos  # about 3 mins
 # 5. build the workspace and deploy firmware for hardware acceleration
 ###################################################
 source /tools/Xilinx/Vitis/2020.2/settings64.sh  # source Xilinx tools
-source /opt/ros/foxy/setup.bash  # Sources system ROS 2 installation. 
-# Note: The path above is valid if one installs ROS 2 from a pre-built 
-# package. If one builds ROS 2 from the source the directory might 
+source /opt/ros/foxy/setup.bash  # Sources system ROS 2 installation.
+# Note: The path above is valid if one installs ROS 2 from a pre-built
+# package. If one builds ROS 2 from the source the directory might
 # vary (e.g. ~/ros2_foxy/ros2-linux).
 export PATH="/usr/bin":$PATH  # FIXME: adjust path for CMake 3.5+
 colcon build --merge-install  # about 2 mins


### PR DESCRIPTION
See https://github.com/ros-acceleration/colcon-acceleration/issues/1
for rationale on how colcon-acceleration wasn't properly
handling exceptions and errors. These changes update
colcon-acceleration to 0.2.0 which includes the appropriate
fixes

Signed-off-by: Víctor Mayoral Vilches <v.mayoralv@gmail.com>