### PR TITLE
Added package dependency: tracetools_acceleration

### DIFF
--- a/sphinx/source/docs/examples/5_faster_ros2_publisher.md
+++ b/sphinx/source/docs/examples/5_faster_ros2_publisher.md
@@ -114,7 +114,7 @@ $ source install/setup.bash
 $ colcon acceleration select kv260
 
 # build faster_doublevadd_publisher
-$ colcon build --build-base=build-kv260 --install-base=install-kv260 --merge-install --mixin kv260 --packages-select ament_acceleration ament_vitis vitis_common ros2acceleration faster_doublevadd_publisher
+$ colcon build --build-base=build-kv260 --install-base=install-kv260 --merge-install --mixin kv260 --packages-select ament_acceleration ament_vitis vitis_common ros2acceleration tracetools_acceleration faster_doublevadd_publisher
 
 # copy to KV260 rootfs, e.g.
 $ scp -r install-kv260/* petalinux@192.168.1.86:/ros2_ws/


### PR DESCRIPTION
This package is required for  faster_doublevadd_publisher example as shown in the below error logs

```
colcon build --build-base=build-kv260 --install-base=install-kv260 --merge-install --mixin kv260 --packages-select ament_acceleration ament_vitis vitis_common ros2acceleration faster_doublevadd_publisher
/usr/lib/python3/dist-packages/pkg_resources/__init__.py:116: PkgResourcesDeprecationWarning: 1.1build1 is an invalid version and will not be supported in a future release
  warnings.warn(
/usr/lib/python3/dist-packages/pkg_resources/__init__.py:116: PkgResourcesDeprecationWarning: 0.1.43ubuntu1 is an invalid version and will not be supported in a future release
  warnings.warn(
[1.092s] WARNING:colcon.colcon_core.package_selection:Some selected packages are already built in one or more underlay workspaces:
	'vitis_common' is in: /opt/ros/humble, /home/spa/krs_1.0_kv260/install, /home/spa/krs_1.0_kr260/install, /home/spa/krs_versal/install
If a package in a merged underlay workspace is overridden and it installs headers, then all packages in the overlay must sort their include directories by workspace order. Failure to do so may result in build failures or undefined behavior at run time.
If the overridden package is used by another package in any underlay, then the overriding package in the overlay must be API and ABI compatible or undefined behavior at run time may occur.

If you understand the risks and want to override a package anyways, add the following to the command line:
	--allow-overriding vitis_common

This may be promoted to an error in a future release of colcon-override-check.
Starting >>> ament_acceleration
Starting >>> ros2acceleration
Finished <<< ament_acceleration [0.62s]                                                        
Starting >>> ament_vitis
Finished <<< ament_vitis [0.23s]                                                        
Starting >>> vitis_common
Finished <<< vitis_common [0.32s]                                                           
Starting >>> faster_doublevadd_publisher
[2.341s] WARNING:colcon.colcon_core.shell:The following packages are in the workspace but haven't been built:
- tracetools_acceleration
They are being used from the following locations instead:
- /home/spa/krs_1.0_kr260/install
To suppress this warning ignore these packages in the workspace:
--packages-ignore tracetools_acceleration
--- stderr: ros2acceleration                                                                          
/usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
---
Finished <<< ros2acceleration [1.43s]
--- stderr: faster_doublevadd_publisher                         
CMake Error at CMakeLists.txt:17 (find_package):
  By not providing "Findtracetools_acceleration.cmake" in CMAKE_MODULE_PATH
  this project has asked CMake to find a package configuration file provided
  by "tracetools_acceleration", but CMake did not find one.

  Could not find a package configuration file provided by
  "tracetools_acceleration" with any of the following names:

    tracetools_accelerationConfig.cmake
    tracetools_acceleration-config.cmake

  Add the installation prefix of "tracetools_acceleration" to
  CMAKE_PREFIX_PATH or set "tracetools_acceleration_DIR" to a directory
  containing one of the above files.  If "tracetools_acceleration" provides a
  separate development package or SDK, be sure it has been installed.


---
Failed   <<< faster_doublevadd_publisher [2.49s, exited with code 1]

Summary: 4 packages finished [4.18s]
  1 package failed: faster_doublevadd_publisher
  2 packages had stderr output: faster_doublevadd_publisher ros2acceleration
```